### PR TITLE
Quick fix for digest email bug

### DIFF
--- a/api/app/controllers/comments_controller.rb
+++ b/api/app/controllers/comments_controller.rb
@@ -24,18 +24,11 @@ class CommentsController < AuthenticatedController
       a.attributes.values[0].value.sub! 'uid:', ''
     }
 
-    # format the links with the correct base url
-    noko_body.css("a").map do |a|
-      a['href'].sub! 'uid:', ''
-      a.attributes["href"].value = "http://#{Rails.application.config.action_mailer.default_url_options[:host]}/##{a['href'].sub! 'uid:', '/users/'}"
-    end
-
     if user_links
-      email_body = noko_body.to_html
       bucket = Bucket.find(comment_params[:bucket_id])
       user_links.each do |userId|
         user = User.find(userId)
-        UserMailer.notify_member_that_they_were_mentioned(author: current_user, member: user, bucket: bucket, body: email_body).deliver_later
+        UserMailer.notify_member_that_they_were_mentioned(author: current_user, member: user, bucket: bucket, body: comment.body_html).deliver_later
       end
     end
     if comment.valid?

--- a/api/app/models/comment.rb
+++ b/api/app/models/comment.rb
@@ -10,4 +10,26 @@ class Comment < ActiveRecord::Base
     membership = user.membership_for(bucket.group)
     membership.archived? ? "[removed user]" : user.name
   end
+
+  def body_html
+    # convert markdown body to html
+    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, extensions = {})
+    red_body = markdown.render(body)
+
+    # break the html into fragments
+    noko_body = Nokogiri::HTML.fragment(red_body)
+
+    # get an array of all the user ids from the link values
+    user_links = noko_body.css("a").map {|a|
+      a.attributes.values[0].value.sub! 'uid:', ''
+    }
+
+    # format the links with the correct base url
+    noko_body.css("a").map do |a|
+      a['href'].sub! 'uid:', ''
+      a.attributes["href"].value = "http://#{Rails.application.config.action_mailer.default_url_options[:host]}/##{a['href'].sub! 'uid:', '/users/'}"
+    end
+
+    noko_body.to_html
+  end
 end

--- a/api/app/views/user_mailer/recent_activity_partials/_comments_on_buckets_user_participated_in.html.erb
+++ b/api/app/views/user_mailer/recent_activity_partials/_comments_on_buckets_user_participated_in.html.erb
@@ -11,7 +11,7 @@
         <a href="<%= "#{root_url}#/buckets/#{bucket.id}" %>"><b><%= bucket.name %></b></a><br>
         <% comments.each do |comment| %>
           <%= comment.user.name %><br>
-          "<%= comment.body %>"<br><br>
+          "<%= comment.body_html %>"<br><br>
         <% end %>
       </li>
     <% end %>


### PR DESCRIPTION
@chime-mu 

Kate just noticed that there is a bug with the comments when the digest email goes out.

<img width="504" alt="screen shot 2018-03-12 at 7 42 35 pm" src="https://user-images.githubusercontent.com/3010270/37319733-90459d4a-262d-11e8-97a9-2f68f9373f70.png">

I'm traveling tomorrow and was hoping to get a fix out for it before I go to bed. I know that this is not an ideal fix but it works and I don't have time to work on it more right now. I can look at it again on Wednesday but am worried that a lot of people will see this bug between now and then. What do you think? Wanna push it and I can rewrite it on Wednesday?