### PR TITLE
Send logs to stdout

### DIFF
--- a/api/scripts/activity-emails
+++ b/api/scripts/activity-emails
@@ -1,2 +1,2 @@
 #! /bin/bash
-cd /cobudget-api; env -i $(cat /root/env-vars) rake cobudget:deliver_recent_activity_emails
+cd /cobudget-api; env -i $(cat /root/env-vars) rake cobudget:deliver_recent_activity_emails > /dev/stdout


### PR DESCRIPTION
The docker containers were filling up with logs which caused #227 and likely #226 . This change sends logs to STDOUT where they become part of dockers logging system which uses log rotation to keep the log size down while also retaining enough information for troubleshooting.