### PR TITLE
Fix invalid criteria when signing up

### DIFF
--- a/ui/app/components/confirm-account-page/confirm-account-page.html
+++ b/ui/app/components/confirm-account-page/confirm-account-page.html
@@ -31,7 +31,7 @@
                   <li>one uppercase character</li>
                   <li>one lowercase character</li>
                   <li>one number</li>
-                  <li>one special character</li>
+                  <li>one of theese special characters: @$!%*?&amp;</li>
                   <li>must be at least 10 characters</li>
                 </ul>
               </div>

--- a/ui/app/components/profile-settings-page/profile-settings-page.html
+++ b/ui/app/components/profile-settings-page/profile-settings-page.html
@@ -61,7 +61,7 @@
                 <li>one uppercase character</li>
                 <li>one lowercase character</li>
                 <li>one number</li>
-                <li>one special character</li>
+                <li>one of theese special characters: @$!%*?&amp;</li>
                 <li>must be at least 10 characters</li>
               </ul>
             </div>

--- a/ui/app/components/reset-password-page/reset-password-page.html
+++ b/ui/app/components/reset-password-page/reset-password-page.html
@@ -17,7 +17,7 @@
               <li>one uppercase character</li>
               <li>one lowercase character</li>
               <li>one number</li>
-              <li>one special character</li>
+              <li>one of theese special characters: @$!%*?&amp;</li>
               <li>must be at least 10 characters</li>
             </ul>
           </div>


### PR DESCRIPTION
This commit addresses "Invalid criteria when signing up" as described in https://github.com/cobudget/cobudget/issues/226

Users were unable to sign up due to the criteria described in the UI not matching the criteria used by the regular expression. The UI has been updated to include a list of acceptable characters.
