### PR TITLE
Fix analytics page with 12 hour caching

### DIFF
--- a/api/app/services/analytics_service.rb
+++ b/api/app/services/analytics_service.rb
@@ -1,3 +1,4 @@
+# Analytics Service
 class AnalyticsService
   def self.report
     self.new.report
@@ -32,84 +33,116 @@ class AnalyticsService
   private
 
     def new_group_count_7
-      Group.where(created_at: 7.days.ago..Time.current).count
+      Rails.cache.fetch("new_group_count_7", :expires_in => 12.hours) do
+        Group.where(created_at: 7.days.ago..Time.current).count
+      done
     end
 
     def new_group_count_90
-      Group.where(created_at: 90.days.ago..Time.current).count
+      Rails.cache.fetch("new_group_count_90", :expires_in => 12.hours) do
+        Group.where(created_at: 90.days.ago..Time.current).count
+      done
     end
 
     def unconfirmed_user_count
-      User.where(confirmed_at: nil).count
+      Rails.cache.fetch("unconfirmed_user_count", :expires_in => 12.hours) do
+        User.where(confirmed_at: nil).count
+      end
     end
 
     def confirmed_user_count
-      User.where.not(confirmed_at: nil).where.not("email like ?", "%admin@group%").count
+      Rails.cache.fetch("confirmed_user_count", :expires_in => 12.hours) do
+        User.where.not(confirmed_at: nil).where.not("email like ?", "%admin@group%").count
+      end
     end
 
     def unconfirmed_user_count_7
-      User.where(created_at: 7.days.ago..Time.current, confirmed_at: nil).count
+      Rails.cache.fetch("unconfirmed_user_count_7", :expires_in => 12.hours) do
+        User.where(created_at: 7.days.ago..Time.current, confirmed_at: nil).count
+      end
     end
 
     def confirmed_user_count_7
-      User.where(created_at: 7.days.ago..Time.current).where.not(confirmed_at: nil).where.not("email like ?", "%admin@group%").count
+      Rails.cache.fetch("confirmed_user_count_7", :expires_in => 12.hours) do
+        User.where(created_at: 7.days.ago..Time.current).where.not(confirmed_at: nil).where.not("email like ?", "%admin@group%").count
+      end
     end
 
     def unconfirmed_user_count_90
-      User.where(created_at: 90.days.ago..Time.current, confirmed_at: nil).count
+      Rails.cache.fetch("unconfirmed_user_count_90", :expires_in => 12.hours) do
+        User.where(created_at: 90.days.ago..Time.current, confirmed_at: nil).count
+      end
     end
 
     def confirmed_user_count_90
-      User.where(created_at: 90.days.ago..Time.current).where.not(confirmed_at: nil).where.not("email like ?", "%admin@group%").count
+      Rails.cache.fetch("confirmed_user_count_90", :expires_in => 12.hours) do
+        User.where(created_at: 90.days.ago..Time.current).where.not(confirmed_at: nil).where.not("email like ?", "%admin@group%").count
+      end
     end
 
     def buckets_count
-      Bucket.all.count
+      Rails.cache.fetch("buckets_count", :expires_in => 12.hours) do
+        Bucket.all.count
+      end
     end
 
     def users_that_proposed_buckets_count
-      Bucket.distinct.count(:user_id)
+      Rails.cache.fetch("users_that_proposed_buckets_count", :expires_in => 12.hours) do
+        Bucket.distinct.count(:user_id)
+      end
     end
 
     def users_that_proposed_buckets_percentage (group)
-       100 * group.buckets.select(:user_id).distinct.count / (group.members.count == 0 ? 1 : group.members.count)
+      Rails.cache.fetch("users_that_proposed_buckets_percentage__#{group.id}_#{group.name}", :expires_in => 12.hours) do
+        100 * group.buckets.select(:user_id).distinct.count / (group.members.count == 0 ? 1 : group.members.count)
+      end
     end
 
     def cumulative_user_invite_count_data
-      User.where(created_at: Date.parse("january 1 2017")..Time.current).where.not("email like ?", "%admin@group%").group_by_day(:created_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      Rails.cache.fetch("cumulative_user_invite_count_data", :expires_in => 12.hours) do
+        User.where(created_at: Date.parse("january 1 2017")..Time.current).where.not("email like ?", "%admin@group%").group_by_day(:created_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      end
     end
 
     def cumulative_group_count_data
-      Group.where(created_at: Date.parse("january 1 2017")..Time.current).group_by_day(:created_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      Rails.cache.fetch("cumulative_group_count_data", :expires_in => 12.hours) do
+        Group.where(created_at: Date.parse("january 1 2017")..Time.current).group_by_day(:created_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      end
     end
 
     def new_buckets_data
-      Bucket.where(created_at: Date.parse("january 1 2017")..Time.current).group_by_day(:created_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      Rails.cache.fetch("new_buckets_data", :expires_in => 12.hours) do
+        Bucket.where(created_at: Date.parse("january 1 2017")..Time.current).group_by_day(:created_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      end
     end
 
     def funded_buckets_data
-      Bucket.where(funded_at: Date.parse("january 1 2017")..Time.current).group_by_day(:funded_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      Rails.cache.fetch("funded_buckets_data", :expires_in => 12.hours) do
+        Bucket.where(funded_at: Date.parse("january 1 2017")..Time.current).group_by_day(:funded_at).count.map {|k,v| [k.strftime('%Q').to_i, v]}
+      end
     end
 
     def group_data
       groups = Group.all
       groups.map do |group|
-        {
-          admins: group.members.joins(:memberships).where(memberships: {is_admin: true}).distinct.order(:created_at).as_json(only: [:name, :email]).map { |h| h.symbolize_keys },
-          id: group.id,
-          created_at: group.created_at,
-          last_activity_at: group.last_activity_at,
-          confirmed_member_count: group.members.where.not(confirmed_at: nil).count,
-          unconfirmed_member_count: group.members.where(confirmed_at: nil).count,
-          name: group.name,
-          currency_symbol: group.currency_symbol,
-          funded_bucket_count: group.buckets.where(status:'funded').count,
-          buckets_last_week: group.buckets.where(created_at: 7.days.ago..Time.current).count,
-          buckets_last_quarter: group.buckets.where(created_at: 90.days.ago..Time.current).count,
-          buckets_all_time: group.buckets.all.count,
-          total_allocations: group.total_allocations,
-          users_that_proposed_buckets_percentage: users_that_proposed_buckets_percentage(group)
-        }
+        Rails.cache.fetch("group_data_#{group.id}_#{group.name}", :expires_in => 12.hours) do
+          {
+            admins: group.members.joins(:memberships).where(memberships: {is_admin: true}).distinct.order(:created_at).as_json(only: [:name, :email]).map { |h| h.symbolize_keys },
+            id: group.id,
+            created_at: group.created_at,
+            last_activity_at: group.last_activity_at,
+            confirmed_member_count: group.members.where.not(confirmed_at: nil).count,
+            unconfirmed_member_count: group.members.where(confirmed_at: nil).count,
+            name: group.name,
+            currency_symbol: group.currency_symbol,
+            funded_bucket_count: group.buckets.where(status: 'funded').count,
+            buckets_last_week: group.buckets.where(created_at: 7.days.ago..Time.current).count,
+            buckets_last_quarter: group.buckets.where(created_at: 90.days.ago..Time.current).count,
+            buckets_all_time: group.buckets.all.count,
+            total_allocations: group.total_allocations,
+            users_that_proposed_buckets_percentage: users_that_proposed_buckets_percentage(group)
+          }
+        end
       end
     end
 end


### PR DESCRIPTION
This is not the ideal solution but it immediately relieves pressure from the database and would allow for each page reload to make "some" progress in executing the analytics page queries. e.g. The first 10 expensive queries would run on the first page load (which would time out eventually), then when the page is reloaded, it would grab those results from the cache and go on to the next 10 expensive queries.

Keen you get your feedback @chime-mu 

Thanks 🙏 