### PR TITLE
Added ability to get user emails with leading and trailing spaces

### DIFF
--- a/api/services/auth.service.js
+++ b/api/services/auth.service.js
@@ -32,8 +32,9 @@ class AuthService {
 
   static async sendMagicLink({ inputEmail, currentOrg, models: { User, Member, Event } }
   ) {
-    if (!isValidEmail(inputEmail)) throw new Error('Not a valid email address');
-    const email = inputEmail.toLowerCase();
+    const trimmedEmail = inputEmail.trim();
+    if (!isValidEmail(trimmedEmail)) throw new Error('Not a valid email address');
+    const email = trimmedEmail.toLowerCase();
   
     let user;
     if(currentOrg) {

--- a/ui/components/LoginModal.js
+++ b/ui/components/LoginModal.js
@@ -1,7 +1,6 @@
 import gql from "graphql-tag";
 import { useMutation } from "@apollo/react-hooks";
 import { useForm } from "react-hook-form";
-
 import { Modal } from "@material-ui/core";
 
 import TextField from "components/TextField";
@@ -18,7 +17,7 @@ export default ({ open, handleClose }) => {
     SEND_MAGIC_LINK_MUTATION
   );
   const { handleSubmit, register, errors } = useForm();
-
+  
   return (
     <Modal
       open={open}
@@ -50,7 +49,7 @@ export default ({ open, handleClose }) => {
                 inputRef={register({
                   required: "Required",
                   pattern: {
-                    value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i,
+                    value: /^[ ]{0,}[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}[ ]{0,}$/i,
                     message: "invalid email address",
                   },
                 })}


### PR DESCRIPTION
#What
- Added ability to get user emails with leading and trailing spaces and trim them on the server

# Screenshots and Tophatting 🎩
Tested for normal emails email@something.com and spaces such as `     email@something.com     ` and also for general invalid emails

<img width="783" alt="Screen Shot 2020-11-01 at 18 05 01" src="https://user-images.githubusercontent.com/1032526/97808074-3fa93980-1c6d-11eb-9fc9-9c9f47562717.png">
<img width="690" alt="Screen Shot 2020-11-01 at 18 05 06" src="https://user-images.githubusercontent.com/1032526/97808075-4172fd00-1c6d-11eb-8c7a-ed3d0b99ce14.png">
<img width="750" alt="Screen Shot 2020-11-01 at 18 05 12" src="https://user-images.githubusercontent.com/1032526/97808076-433cc080-1c6d-11eb-9853-6dacd6bae6f5.png">
<img width="702" alt="Screen Shot 2020-11-01 at 18 05 18" src="https://user-images.githubusercontent.com/1032526/97808077-45068400-1c6d-11eb-829a-ae6d60905c13.png">
<img width="713" alt="Screen Shot 2020-11-01 at 18 06 25" src="https://user-images.githubusercontent.com/1032526/97808078-4768de00-1c6d-11eb-8492-03339dfb517c.png">
