### PR TITLE
fix: review option visibility

### DIFF
--- a/ui/components/Bucket/Sidebar.tsx
+++ b/ui/components/Bucket/Sidebar.tsx
@@ -189,7 +189,7 @@ const BucketSidebar = ({ bucket, currentUser, canEdit, showBucketReview }) => {
               >
                 Fund
               </Button>
-              {showBucketReview ? <Monster bucket={bucket} /> : null}
+              
               {contributeModalOpen && (
                 <ContributeModal
                   handleClose={() => setContributeModalOpen(false)}
@@ -199,6 +199,10 @@ const BucketSidebar = ({ bucket, currentUser, canEdit, showBucketReview }) => {
               )}
             </>
           )}
+          {
+            (showBucketReview || canEdit || (bucket.cocreators.find(co => co.id === currentUser?.currentCollMember?.id)))
+            ? <Monster bucket={bucket} /> : null
+          }
           {showAcceptFundingButton && (
             <Button
               color={bucket.round.color}

--- a/ui/components/Bucket/Sidebar.tsx
+++ b/ui/components/Bucket/Sidebar.tsx
@@ -189,7 +189,7 @@ const BucketSidebar = ({ bucket, currentUser, canEdit, showBucketReview }) => {
               >
                 Fund
               </Button>
-              
+
               {contributeModalOpen && (
                 <ContributeModal
                   handleClose={() => setContributeModalOpen(false)}
@@ -199,10 +199,13 @@ const BucketSidebar = ({ bucket, currentUser, canEdit, showBucketReview }) => {
               )}
             </>
           )}
-          {
-            (showBucketReview || canEdit || (bucket.cocreators.find(co => co.id === currentUser?.currentCollMember?.id)))
-            ? <Monster bucket={bucket} /> : null
-          }
+          {showBucketReview ||
+          canEdit ||
+          bucket.cocreators.find(
+            (co) => co.id === currentUser?.currentCollMember?.id
+          ) ? (
+            <Monster bucket={bucket} />
+          ) : null}
           {showAcceptFundingButton && (
             <Button
               color={bucket.round.color}

--- a/ui/components/InviteMembersModal.tsx
+++ b/ui/components/InviteMembersModal.tsx
@@ -190,7 +190,7 @@ const InviteMembersModal = ({
                       navigator.clipboard
                         .writeText(link)
                         .then(() => toast.success("Invitation link copied"))
-                        .catch(() => toast.error("Error while copying link"))
+                        .catch(() => toast.error("Error while copying link"));
                     }}
                   >
                     Copy
@@ -206,13 +206,14 @@ const InviteMembersModal = ({
                       onClick={() => {
                         deleteInviteLink({
                           roundId,
-                        })
-                        .then(result => {
+                        }).then((result) => {
                           if (result.error) {
-                            return toast.error("Could not delete invitation link");
+                            return toast.error(
+                              "Could not delete invitation link"
+                            );
                           }
-                          toast.success("Invitation link deleted")
-                        })
+                          toast.success("Invitation link deleted");
+                        });
                       }}
                     >
                       <DeleteIcon className="h-5 w-5" />
@@ -235,13 +236,12 @@ const InviteMembersModal = ({
                 onClick={() => {
                   createInviteLink({
                     roundId,
-                  })
-                  .then((result) => {
+                  }).then((result) => {
                     if (result.error) {
-                      return toast.error("Could not create invite link")
+                      return toast.error("Could not create invite link");
                     }
-                    toast.success("Invite link created")
-                  })
+                    toast.success("Invite link created");
+                  });
                 }}
               >
                 Create Invite Link


### PR DESCRIPTION
Review option will be visible
1. to all members of a round if the bucket is published
2. always to round admin, moderator and the bucket co-creators even if the bucket is not published

Condition: Review should be enabled from round settings and guidelines should be there.