### PR TITLE
Bucket publish mail settings

### DIFF
--- a/ui/components/UserSettings/index.tsx
+++ b/ui/components/UserSettings/index.tsx
@@ -43,7 +43,7 @@ const settingsMeta = [
   },
   {
     key: "bucketPublishedInRound",
-    label: `A new ${process.env.BUCKET_NAME_PLURAL} is published`,
+    label: `A new ${process.env.BUCKET_NAME_SINGULAR} is published`,
   },
   {
     key: "commentBecauseCommented",

--- a/ui/server/prisma/migrations/20220508212742_bucket_published_change_default_value/migration.sql
+++ b/ui/server/prisma/migrations/20220508212742_bucket_published_change_default_value/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "EmailSettings" ALTER COLUMN "bucketPublishedInRound" SET DEFAULT false;

--- a/ui/server/prisma/schema.prisma
+++ b/ui/server/prisma/schema.prisma
@@ -34,7 +34,7 @@ model EmailSettings {
   commentBecauseCommented        Boolean @default(true)
   allocatedToYou                 Boolean @default(true)
   refundedBecauseBucketCancelled Boolean @default(true)
-  bucketPublishedInRound         Boolean @default(true)
+  bucketPublishedInRound         Boolean @default(false)
   contributionToYourBucket       Boolean @default(true)
   roundJoinRequest               Boolean @default(true)
   user                           User    @relation(fields: [userId], references: [id])

--- a/ui/server/services/EmailService/email.service.ts
+++ b/ui/server/services/EmailService/email.service.ts
@@ -503,7 +503,7 @@ export default {
         (collMember) => !cocreators.map((co) => co.id).includes(collMember.id)
       )
       .map((collMember) => collMember.user)
-      .filter((user) => user.emailSettings?.bucketPublishedInRound ?? true);
+      .filter((user) => user.emailSettings?.bucketPublishedInRound ?? false);
 
     const collLink = appLink(`/${currentGroup.slug}/${round.slug}`);
 


### PR DESCRIPTION
for https://github.com/cobudget/cobudget/issues/702 and a typo fix. Bucket should be singular.


<img width="508" alt="Screen Shot 2022-05-09 at 2 34 40 AM" src="https://user-images.githubusercontent.com/38759611/167316771-416e111d-8158-44f7-baa3-d3bfddcf3760.png">
