### PR TITLE
fix: in case of no filter show all

### DIFF
--- a/ui/components/Filterbar/StatusFilter.tsx
+++ b/ui/components/Filterbar/StatusFilter.tsx
@@ -67,7 +67,7 @@ export default function StatusFilter({
                           (status) => status !== item.type
                         );
                         if (statusList.length === 0) {
-                          onChangeStatus(["HIDE_ALL"]);
+                          onChangeStatus();
                         } else onChangeStatus(statusList);
                       } else {
                         // add to filter

--- a/ui/components/Filterbar/index.js
+++ b/ui/components/Filterbar/index.js
@@ -52,16 +52,29 @@ const Filterbar = ({
   };
 
   const onChangeStatus = (statusFilterArray) => {
-    router.push({
-      pathname: "/[group]/[round]",
-      query: {
-        group: router.query.group,
-        round: router.query.round,
-        ...(tag && { tag }),
-        ...(!!input && { s: input }),
-        f: statusFilterArray,
-      },
-    });
+    if (typeof statusFilterArray === "undefined") {
+      router.push({
+        pathname: "/[group]/[round]",
+        query: {
+          group: router.query.group,
+          round: router.query.round,
+          ...(tag && { tag }),
+          ...(!!input && { s: input }),
+        },
+      });
+    }
+    else {
+      router.push({
+        pathname: "/[group]/[round]",
+        query: {
+          group: router.query.group,
+          round: router.query.round,
+          ...(tag && { tag }),
+          ...(!!input && { s: input }),
+          f: statusFilterArray,
+        },
+      });
+    }
   };
   const onChangeView = (view) => {
     router.push({

--- a/ui/pages/[group]/[round]/index.tsx
+++ b/ui/pages/[group]/[round]/index.tsx
@@ -396,12 +396,15 @@ const getStandardFilter = (bucketStatusCount) => {
   // if there is either pending or open for funding buckets, show those categories
   if (
     bucketStatusCount["PENDING_APPROVAL"] ||
-    bucketStatusCount["OPEN_FOR_FUNDING"]
+    bucketStatusCount["OPEN_FOR_FUNDING"] ||
+    bucketStatusCount["COMPLETED"]
   ) {
     if (bucketStatusCount["PENDING_APPROVAL"])
       stdFilter.push("PENDING_APPROVAL");
     if (bucketStatusCount["OPEN_FOR_FUNDING"])
       stdFilter.push("OPEN_FOR_FUNDING");
+    if (bucketStatusCount["COMPLETED"])
+      stdFilter.push("COMPLETED");
   } else {
     // otherwise show every other
     const statusNames = Object.keys(bucketStatusCount);


### PR DESCRIPTION
for https://github.com/cobudget/cobudget/issues/726#issuecomment-1172236356

In the last MR it was done like this if there are no filters selected status filters, I hid all the buckets.

Now, if no filter is selected, all filters are selected automatically.

https://user-images.githubusercontent.com/38759611/177030034-b2473580-9749-4b3d-9d44-b4ac16ada6d4.mov

