### PR TITLE
unselect canceled buckets

### DIFF
--- a/ui/server/graphql/resolvers/queries/bucket.ts
+++ b/ui/server/graphql/resolvers/queries/bucket.ts
@@ -44,12 +44,14 @@ export const bucketsPage = async (
     currentMember && (currentMember.isAdmin || currentMember.isModerator);
 
   const statusFilter = status.map(statusTypeToQuery).filter((s) => s);
-
+  // If cancelled in not there in the status filter, explicitly qunselect canceled buckets
+  const showCanceled = status.indexOf('CANCELED') === -1;
   const buckets = await prisma.bucket.findMany({
     where: {
       round: { slug: roundSlug, group: { slug: groupSlug ?? "c" } },
       deleted: { not: true },
       OR: statusFilter,
+      ...(showCanceled && { canceledAt: null }),
       ...(textSearchTerm && { title: { search: textSearchTerm } }),
       ...(tagValue && {
         tags: { some: { value: tagValue } },

--- a/ui/server/graphql/resolvers/queries/bucket.ts
+++ b/ui/server/graphql/resolvers/queries/bucket.ts
@@ -44,7 +44,7 @@ export const bucketsPage = async (
     currentMember && (currentMember.isAdmin || currentMember.isModerator);
 
   const statusFilter = status.map(statusTypeToQuery).filter((s) => s);
-  // If cancelled in not there in the status filter, explicitly qunselect canceled buckets
+  // If canceled in not there in the status filter, explicitly qunselect canceled buckets
   const showCanceled = status.indexOf('CANCELED') === -1;
   const buckets = await prisma.bucket.findMany({
     where: {

--- a/ui/server/graphql/resolvers/queries/bucket.ts
+++ b/ui/server/graphql/resolvers/queries/bucket.ts
@@ -45,7 +45,7 @@ export const bucketsPage = async (
 
   const statusFilter = status.map(statusTypeToQuery).filter((s) => s);
   // If canceled in not there in the status filter, explicitly qunselect canceled buckets
-  const showCanceled = status.indexOf('CANCELED') === -1;
+  const showCanceled = status.indexOf("CANCELED") === -1;
   const buckets = await prisma.bucket.findMany({
     where: {
       round: { slug: roundSlug, group: { slug: groupSlug ?? "c" } },


### PR DESCRIPTION
for https://github.com/cobudget/cobudget/issues/887

There is another way for fixing the issue through the `statusTypeToQuery` helper function. But the issue in using that function is that it required to add `canceledAt: null` with every filter and this increases chances of bugs IMO. That is why I haven't used this function and unselected canceled buckets without using this function.