### PR TITLE
fix: added from group toast

### DIFF
--- a/ui/components/InviteMembersModal.tsx
+++ b/ui/components/InviteMembersModal.tsx
@@ -197,7 +197,8 @@ const InviteMembersModal = ({
         toast.success("Added all members from group");
       }
     }
-  }, [groupMembers, emails]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupMembers]);
 
   useEffect(() => {
     setUpdatingEmails(false);

--- a/ui/utils/url.ts
+++ b/ui/utils/url.ts
@@ -1,3 +1,3 @@
 export const extractEmail = (text: string) => {
-  return text.match(/([a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/gi);
+  return text.match(/([a-zA-Z0-9.+_-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)/gi);
 };


### PR DESCRIPTION
Fix for a small issue.  When a member is removed and then the emails are edited, the toast is shown again and again.


<img width="765" alt="Screenshot 2023-02-21 at 2 20 49 AM" src="https://user-images.githubusercontent.com/38759611/220200145-0acedfc0-a8ae-4108-8577-170ebb173098.png">
