### PR TITLE
Fix/edit expense bucket

### DIFF
--- a/ui/components/RoundExpenses.tsx
+++ b/ui/components/RoundExpenses.tsx
@@ -396,13 +396,15 @@ function RoundExpenses({ round, currentUser }) {
                               {bucketsMap[expense.bucketId]?.title}
                             </span>
                           </Link>
-                        ) : (
+                        ) : isAdmin ? (
                           <i
                             onClick={() => setExpenseToEdit(expense)}
                             className="cursor-pointer"
                           >
                             Assign Bucket
                           </i>
+                        ) : (
+                          <i>No Bucket Assigned</i>
                         )}
                       </TableCell>
                       <TableCell>


### PR DESCRIPTION
"Assign Bucket" hidden and replaced by "No bucket assigned" for the non-admins on round expenses page.