### PR TITLE
Fix: sync expense receipts (CHECK COMMENT)

### DIFF
--- a/ui/server/prisma/migrations/20230825061457_unique_oc_expense_receipt/migration.sql
+++ b/ui/server/prisma/migrations/20230825061457_unique_oc_expense_receipt/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[ocExpenseReceiptId]` on the table `ExpenseReceipt` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "ExpenseReceipt_ocExpenseReceiptId_key" ON "ExpenseReceipt"("ocExpenseReceiptId");

--- a/ui/server/prisma/schema.prisma
+++ b/ui/server/prisma/schema.prisma
@@ -60,7 +60,7 @@ model ExpenseReceipt {
   attachment         String?
   expense            Expense? @relation(fields: [expenseId], references: [id])
   expenseId          String? 
-  ocExpenseReceiptId String?
+  ocExpenseReceiptId String?  @unique
 }
 
 enum ExpenseStatus {

--- a/ui/server/webhooks/ochandlers.ts
+++ b/ui/server/webhooks/ochandlers.ts
@@ -152,16 +152,12 @@ export const handleExpenseChange = async (req, res) => {
           expenseId: dbExpense.id as string,
           ocExpenseReceiptId: item.id,
         };
-        if (existing) {
-          return prisma.expenseReceipt.update({
-            where: { id: existing.id },
-            data: receiptData,
-          });
-        } else {
-          return prisma.expenseReceipt.create({
-            data: receiptData,
-          });
-        }
+
+        prisma.expenseReceipt.upsert({
+          where: { ocExpenseReceiptId: item.id },
+          create: receiptData,
+          update: receiptData,
+        });
       });
     } else {
       throw new Error("Expense id missing");


### PR DESCRIPTION
**Before merging, remove duplicated**

In this PR, unique constraint is added to `ocExpenseReceiptId`. For the migration to be successful, first the duplicate rows have to be removed. To view the duplicate rows, use the following query:

```
SELECT "ocExpenseReceiptId", "description", "id", "expenseId"
FROM "ExpenseReceipt"
WHERE "ocExpenseReceiptId" IN (
    SELECT "ocExpenseReceiptId"
    FROM "ExpenseReceipt"
    GROUP BY "ocExpenseReceiptId"
    HAVING COUNT("ocExpenseReceiptId") > 1
);
```

After removing, use the above query to make sure there are no duplicate rows left. After confirmation, merge this PR.